### PR TITLE
load VERSION separately in the gemspec to not hit own dependencies

### DIFF
--- a/lib/mws-connect.rb
+++ b/lib/mws-connect.rb
@@ -12,9 +12,7 @@ module Mws
   autoload :Serializer, 'mws/serializer'
   autoload :Signer, 'mws/signer'
   autoload :Utils, 'mws/utils'
-
-  # The current version of this ruby gem
-  VERSION = '0.0.4'
+  autoload :VERSION, 'mws/version'
 
   Utils.alias self, Apis::Feeds, 
     :Distance,

--- a/lib/mws/version.rb
+++ b/lib/mws/version.rb
@@ -1,0 +1,4 @@
+module Mws
+  # The current version of this ruby gem
+  VERSION = '0.0.4'
+end

--- a/mws-connect.gemspec
+++ b/mws-connect.gemspec
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'mws-connect'
+
+require File.expand_path('../lib/mws/version.rb', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = 'mws-connect'


### PR DESCRIPTION
without this, bundling without an installed nokogiri (beside others) may not be possible
